### PR TITLE
Adds a spec to test for Sinatra errors

### DIFF
--- a/spec/basic_sinatra_forms_spec.rb
+++ b/spec/basic_sinatra_forms_spec.rb
@@ -20,6 +20,13 @@ describe App do
   end
 
   describe 'POST /team' do
+    it 'does not return Sinatra error page' do
+      visit '/newteam'
+
+      click_button "submit"
+      expect(page).to_not have_text("Backtrace")
+    end
+
     it "displays the basketball team name in the browser" do 
       visit '/newteam'
 


### PR DESCRIPTION
Because the Sinatra error page shows a table of Variables and Values, if
there is a Ruby error in the code, the specs will all pass.  This commit
adds adds a spec to check for 'backtrace' text that would indicate the
error page.
